### PR TITLE
Ambiguous "id" column when using joins 

### DIFF
--- a/lib/big_sitemap.rb
+++ b/lib/big_sitemap.rb
@@ -132,7 +132,8 @@ class BigSitemap
           find_options[key] = options.delete(key)
         end
 
-        primary_column   = options.delete(:primary_column)
+        primary_method   = options.delete(:primary_column)
+        primary_column   = "#{table_name(model)}.#{primary_method}"
 
         count = model.send(count_method, find_options.merge(:select => (primary_column || '*'), :include => nil))
         count = find_options[:limit].to_i if find_options[:limit] && find_options[:limit].to_i < count
@@ -185,7 +186,7 @@ class BigSitemap
               priority = options[:priority]
               pri = priority.is_a?(Proc) ? priority.call(record) : priority
 
-              last_id = primary_column ? record.send(primary_column) : nil
+              last_id = primary_column ? record.send(primary_method) : nil
               sitemap.add_url!(location, last_mod, freq, pri, last_id)
             end
           end
@@ -254,7 +255,7 @@ class BigSitemap
     @sources.each do |model, options|
       if options[:partial_update] && (primary_column = options[:primary_column]) && (last_id = get_last_id(options[:filename]))
         primary_column_value       = escape_if_string last_id #escape '
-        options[:conditions]       = [options[:conditions], "(#{primary_column} >= #{primary_column_value})"].compact.join(' AND ')
+        options[:conditions]       = [options[:conditions], "(#{table_name(model)}.#{primary_column} >= #{primary_column_value})"].compact.join(' AND ')
         options[:start_part_id]    = last_id
       end
     end

--- a/test/big_sitemap_test.rb
+++ b/test/big_sitemap_test.rb
@@ -304,10 +304,10 @@ class BigSitemapTest < Test::Unit::TestCase
         add_model(:num_items => 50) #TestModel
 
         File.open("#{filename}_23.xml", 'w')
-        assert_equal "(id >= 23)", @sitemap.send(:prepare_update).first.last[:conditions]
+        assert_equal "(test_models.id >= 23)", @sitemap.send(:prepare_update).first.last[:conditions]
 
         File.open("#{filename}_42.xml", 'w')
-        assert_equal "(id >= 23) AND (id >= 42)", @sitemap.send(:prepare_update).first.last[:conditions]
+        assert_equal "(test_models.id >= 23) AND (test_models.id >= 42)", @sitemap.send(:prepare_update).first.last[:conditions]
       end
 
       should 'generate correct condition for partial update with custom column' do
@@ -317,7 +317,7 @@ class BigSitemapTest < Test::Unit::TestCase
         add_model(:num_items => 50, :primary_column => 'name') #TestModel
 
         File.open("#{filename}_666.xml", 'w')
-        assert_equal "(name >= 666)", @sitemap.send(:prepare_update).first.last[:conditions]
+        assert_equal "(test_models.name >= 666)", @sitemap.send(:prepare_update).first.last[:conditions]
       end
     end
 


### PR DESCRIPTION
When you bring joins into the picture when defining :conditions for models to be added to the sitemap, the primary_column is still assumed to be id. Therefore, when splitting result sets, you're left with a query that looks for models with an (ambiguous) id > 123. Invalid SQL, as you'd expect.

One would assume this could be fixed by passing a custom primary_column of, for example, posts.id, but this causes another issue when the gem attempts to call the primary_column method on the objects in question (for example, this would call posts.id upon a Post).
