### PR TITLE
Better Performance when fetching objects from DB

### DIFF
--- a/lib/big_sitemap.rb
+++ b/lib/big_sitemap.rb
@@ -260,6 +260,9 @@ class BigSitemap
           find_options[key] = options.delete(key)
         end
 
+        # Keep the intial conditions for later user
+        conditions = find_options[:conditions]
+
         primary_method   = options.delete(:primary_column)
         primary_column   = "#{table_name(model)}.#{primary_method}"
 
@@ -287,7 +290,7 @@ class BigSitemap
             if last_id && primary_column
               find_options.update(:limit => limit, :offset => nil)
               primary_column_value = escape_if_string last_id #escape '
-              find_options.update(:conditions => [find_options[:conditions], "(#{primary_column} > #{primary_column_value})"].compact.join(' AND '))
+              find_options[:conditions] = [conditions, "(#{primary_column} > #{primary_column_value})"].compact.join(' AND ')
             end
 
             model.send(find_method, find_options).each do |record|


### PR DESCRIPTION
Hi,

when using big_sitemap the SQL Queries for fetching the objects from the db would concatenate the WHERE conditions from the query before. This looks something like this:

SELECT \* FROM `table` WHERE ((table.id > 11439258) AND (table.id > 15757399) AND ...
SELECT \* FROM `table` WHERE ((table.id > 11439258) AND (table.id > 15757399) AND AND (table.id > 16456399) ...

And so on, this causes an endless db query wich takes longer and longer for large object counts.

With my fix it looks like this:

SELECT \* FROM `table` WHERE ((table.id > 181306845)) LIMIT 1001
SELECT \* FROM `table` WHERE ((table.id > 186953272)) LIMIT 1001

All test are running. Would be cool, if you could merge it in. I'm using ruby 1.8.7 and MySQL 5.5

Cheers, Christoph
