### PR TITLE
add_urls

### DIFF
--- a/lib/big_sitemap.rb
+++ b/lib/big_sitemap.rb
@@ -179,7 +179,7 @@ class BigSitemap
 
     with_sitemap do |builder|
       @paths.each do |path, options|
-        url = File.join @options[:base_url], File.basename(path)
+        url = File.join @options[:base_url], File.path(path)
         builder.add_url! url, options
       end
     end


### PR DESCRIPTION
File.basename is truncating the string containing the full path for the url.  I have changed it to just File.path.
