### PR TITLE
Generate the correct full url 

### DIFF
--- a/lib/big_sitemap.rb
+++ b/lib/big_sitemap.rb
@@ -179,7 +179,7 @@ class BigSitemap
 
     with_sitemap do |builder|
       @paths.each do |path, options|
-        url = File.join @options[:base_url], File.path(path)
+        url = URI.join(@options[:base_url], path)
         builder.add_url! url, options
       end
     end

--- a/test/big_sitemap_test.rb
+++ b/test/big_sitemap_test.rb
@@ -44,12 +44,12 @@ class BigSitemapTest < Test::Unit::TestCase
   should 'should add paths' do
     generate_sitemap do
       add '/', {:last_modified => Time.now, :change_frequency => 'weekly', :priority => 0.5}
-      add '/about', {:last_modified => Time.now, :change_frequency => 'weekly', :priority => 0.5}
+      add '/navigation/about/us', {:last_modified => Time.now, :change_frequency => 'weekly', :priority => 0.5}
     end
 
     elems = elements first_sitemap_file, 'loc'
     assert_equal 'http://example.com/', elems.first.text
-    assert_equal 'http://example.com/about', elems.last.text
+    assert_equal 'http://example.com/navigation/about/us', elems.last.text
   end
 
   context 'Sitemap index file' do


### PR DESCRIPTION
The generated full url is incorrect, but the applied fix [1] only works for 1.9.1+ ruby version.

As the URL manipulation has nothing to do with the File object, I've replaced it with call to URI.

Only tested on ruby 1.8.7

[1] https://github.com/alexrabarts/big_sitemap/commit/9205a7377782acbfd62820ac3bfc6edd17fa0bf4
