### PR TITLE
Adding support for static and dynamic collections

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -21,6 +21,13 @@ BigSitemap is best run periodically through a Rake/Thor task.
     Product.find(:all).each do |product|
       add product_path(product), :change_frequency => 'daily', :priority => 0.5
     end
+
+    # Add a dynamic collection (using a scope) and calling a method for (vanity) URL to add
+    add_collection Product.live_products, 'method_to_call_for_url'
+
+    # Add a static collection of pages - useful for batching similar pages together and keeping things DRY and managable
+    static_pages_for_sitemap = %w(/terms_and_conditions /privacy_policy /contact_us)
+    add_static_collection static_pages_for_sitemap, :last_modified => Time.now, :change_frequency => 'weekly', :priority => 0.5
   end
 
 The code above will create a minimum of two files:

--- a/lib/big_sitemap.rb
+++ b/lib/big_sitemap.rb
@@ -47,6 +47,18 @@ class BigSitemap
     def add(path, options={})
       @sitemap.add_path(path, options)
     end
+
+    def add_collection(collection, url_method='url_for_sitemap', options={})
+      collection.each do |member|
+          add member.send(url_method), options
+      end
+    end
+
+    def add_static_collection(collection, options={})
+      collection.each do |member|
+        add member, options
+      end
+    end
   end
 
   def initialize(options={})

--- a/test/big_sitemap_test.rb
+++ b/test/big_sitemap_test.rb
@@ -52,6 +52,27 @@ class BigSitemapTest < Test::Unit::TestCase
     assert_equal 'http://example.com/navigation/about/us', elems.last.text
   end
 
+  should 'add to dynamic collection to sitemap' do
+    generate_sitemap do
+      add_collection TestModel.find_for_sitemap(:limit => 3), 'url_for_sitemap', {:last_modified => Time.now, :change_frequency => 'weekly', :priority => 0.5}
+    end
+
+    elems = elements first_sitemap_file, 'loc'
+    assert_equal 3, elems.size
+  end
+
+  should 'add to static collection to sitemap' do
+    generate_sitemap do
+      static_pages_for_sitemap = %w(/terms_and_conditions /privacy_policy /contact_us)
+      add_static_collection static_pages_for_sitemap, {:last_modified => Time.now, :change_frequency => 'weekly', :priority => 0.5}
+    end
+
+    elems = elements first_sitemap_file, 'loc'
+    assert_equal 3, elems.size
+    assert_equal 'http://example.com/terms_and_conditions', elems.first.text
+    assert_equal 'http://example.com/contact_us', elems.last.text
+  end
+
   context 'Sitemap index file' do
     should 'contain one sitemapindex element' do
       generate_sitemap { add '/' }

--- a/test/fixtures/test_model.rb
+++ b/test/fixtures/test_model.rb
@@ -19,6 +19,10 @@ class TestModel
     Time.at(1000000000)
   end
 
+  def url_for_sitemap
+    '/test_model/' + id.to_s
+  end
+
   class << self
     def table_name
       'test_models'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require 'bundler/setup'
 require 'test/unit'
 require 'shoulda'
 require 'mocha'
-require 'test/fixtures/test_model'
+require File.expand_path('fixtures/test_model')
 
 require 'big_sitemap'
 


### PR DESCRIPTION
Adding support for static and dynamic collections. (Dynamic collections can call a method to get a URL from each object in the collection - keeps things DRY)

Background - I've been using Big_sitemap for generating a sitemap dynamically, passing in collections returned by scope, and then calling a method to get the URL for that object instance. Different models have slightly different methods to call for vanity URLs (and some classes have multiple methods for different URLs).

Building a sitemap this way using blocks in the BigSitemap.generate() block was getting a bit messy so I reopened the BigSitemap class and added a couple of methods to DRY things up ........ submitting the pull request as I think other may find it useful - I'm prepared to tweak, incorporate feedback and try a second explanation in the README if it's not clear enough.

Regards,
Wesley
@wesg