### PR TITLE
Google Video Sitemap Support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,10 +5,10 @@ PATH
 
 GEM
   specs:
-    mocha (0.9.10)
-      rake
+    metaclass (0.0.1)
+    mocha (0.12.0)
+      metaclass (~> 0.0.1)
     nokogiri (1.4.4)
-    rake (0.8.7)
     shoulda (2.11.3)
 
 PLATFORMS

--- a/test/big_sitemap_test.rb
+++ b/test/big_sitemap_test.rb
@@ -59,17 +59,17 @@ class BigSitemapTest < Test::Unit::TestCase
     end
 
     should 'contain one sitemap element' do
-      generate_sitemap { add '/' }  
+      generate_sitemap { add '/' }
       assert_equal 1, num_elements(sitemaps_index_file, 'sitemap')
     end
 
     should 'contain one loc element' do
-      generate_sitemap { add '/' }  
+      generate_sitemap { add '/' }
       assert_equal 1, num_elements(sitemaps_index_file, 'loc')
     end
 
     should 'contain one lastmod element' do
-      generate_sitemap { add '/' }  
+      generate_sitemap { add '/' }
       assert_equal 1, num_elements(sitemaps_index_file, 'lastmod')
     end
 
@@ -176,6 +176,24 @@ class BigSitemapTest < Test::Unit::TestCase
 
       assert_equal 2, num_elements(first_sitemap_file, 'priority')
       assert_equal 2, num_elements(second_sitemap_file, 'priority')
+    end
+
+    should 'allow adding video elements' do
+      video_title = "Maru Motel"
+      video_url   = "http://www.youtube.com/embed/cvnPBZbth3E?rel=0"
+      video_date  = Time.mktime(2010, 8, 29)
+
+      generate_sitemap do
+        add '/', :video => { :title            => video_title,
+                             :player_loc       => { :value       => video_url,
+                                                    :allow_embed => true },
+                             :publication_date => video_date
+                           }
+      end
+
+      assert_equal video_title, elements(first_sitemap_file, "*[name()='video:title']").first.text
+      assert_equal video_url,   elements(first_sitemap_file, "*[name()='video:player_loc']").first.text
+      assert_equal "true",      elements(first_sitemap_file, "*[name()='video:player_loc']").first.attributes["allow_embed"].value
     end
 
     should 'not be gzipped' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,13 +55,13 @@ class Test::Unit::TestCase
   end
 
   def ns
-    {'s' => 'http://www.sitemaps.org/schemas/sitemap/0.9'}
+    {'s' => 'http://www.sitemaps.org/schemas/sitemap/0.9', 'v' => "http://www.google.com/schemas/sitemap-video/1.1"}
   end
 
   def elements(filename, el)
     file_class = filename.include?('.gz') ? Zlib::GzipReader : File
     data = Nokogiri::XML.parse(file_class.open(filename).read)
-    data.search("//s:#{el}", ns)
+    data.search("//s:#{el}", "//v:#{el}", ns)
   end
 
   def num_elements(filename, el)


### PR DESCRIPTION
As per http://support.google.com/webmasters/bin/answer.py?hl=en&answer=80472#1

It is tested, but it's missing help, I could add that to a Wiki page or to the README if you'd like? 

Also, you may or may not be happy about including the video namespace all the time - in which case I can make the change to that being dynamic and only included if you have > 1 :video option somewhere.
